### PR TITLE
Add spaces to X-SMTP header

### DIFF
--- a/lib/send_grid/api_header.rb
+++ b/lib/send_grid/api_header.rb
@@ -27,7 +27,7 @@ class SendGrid::ApiHeader
   end
 
   def to_json
-    JSON.generate(@data, :indent => ' ')
+    JSON.generate(@data, :indent => ' ').gsub("\n", '')
   end
 end
 


### PR DESCRIPTION
Hi

Sending emails to large number of recipients I've encountered such error:

> A message was received from this address by our systems that had errors in the smtpapi header, and cannot be processed.
> The error detected was: Error decoding SMTP API header

The reason was in X-SMTP header, which was too large and was not broken down with spaces properly.
The way how to avoid this problem is described here: http://docs.sendgrid.com/documentation/api/smtp-api/developers-guide/

This pull-request adds spaces to header, so problem seems to be resolved.
There is one drawback there that header size increases 1.5 times. You can probably find better solution.

Thanks
