### PR TITLE
Add support for `send_at` X-SMTPAPI parameter

### DIFF
--- a/lib/send_grid.rb
+++ b/lib/send_grid.rb
@@ -7,7 +7,7 @@ module SendGrid
   def self.included(base)
     base.class_eval do
       include InstanceMethods
-      delegate :substitute, :uniq_args, :category, :add_filter_setting, :add_send_at, :to => :sendgrid_header
+      delegate :substitute, :uniq_args, :category, :add_filter_setting, :deliver_at, :to => :sendgrid_header
       alias_method_chain :mail, :sendgrid
       alias_method :sendgrid_header, :send_grid_header
     end

--- a/lib/send_grid.rb
+++ b/lib/send_grid.rb
@@ -7,7 +7,7 @@ module SendGrid
   def self.included(base)
     base.class_eval do
       include InstanceMethods
-      delegate :substitute, :uniq_args, :category, :add_filter_setting, :to => :sendgrid_header
+      delegate :substitute, :uniq_args, :category, :add_filter_setting, :add_send_at, :to => :sendgrid_header
       alias_method_chain :mail, :sendgrid
       alias_method :sendgrid_header, :send_grid_header
     end

--- a/lib/send_grid/api_header.rb
+++ b/lib/send_grid/api_header.rb
@@ -26,7 +26,7 @@ class SendGrid::ApiHeader
     @data[:filters][fltr][:settings][setting] = val
   end
 
-  def add_send_at(timestamp)
+  def deliver_at(timestamp)
     @data[:send_at] = timestamp
   end
 

--- a/lib/send_grid/api_header.rb
+++ b/lib/send_grid/api_header.rb
@@ -26,6 +26,10 @@ class SendGrid::ApiHeader
     @data[:filters][fltr][:settings][setting] = val
   end
 
+  def send_at(timestamp)
+    @data[:send_at] = timestamp
+  end
+
   def to_json
     JSON.generate(@data, :array_nl => ' ')
   end

--- a/lib/send_grid/api_header.rb
+++ b/lib/send_grid/api_header.rb
@@ -26,7 +26,7 @@ class SendGrid::ApiHeader
     @data[:filters][fltr][:settings][setting] = val
   end
 
-  def send_at(timestamp)
+  def add_send_at(timestamp)
     @data[:send_at] = timestamp
   end
 

--- a/spec/api_header_spec.rb
+++ b/spec/api_header_spec.rb
@@ -34,7 +34,7 @@ describe SendGrid::ApiHeader do
 
     it "contains send_at" do
       ts = 5.minutes.from_now.to_i
-      header.add_send_at ts
+      header.deliver_at ts
       header.to_json.should eql "{\"send_at\":#{ts}}"
     end
 

--- a/spec/api_header_spec.rb
+++ b/spec/api_header_spec.rb
@@ -32,6 +32,12 @@ describe SendGrid::ApiHeader do
       header.to_json.should eql '{"category":"category_name"}'
     end
 
+    it "contains send_at" do
+      ts = 5.minutes.from_now.to_i
+      header.send_at ts
+      header.to_json.should eql "{\"send_at\":#{ts}}"
+    end
+
     it "contains filter settings" do
       header.add_filter_setting :filter1, :setting1, 'val1'
       header.to_json.should eql '{"filters":{"filter1":{"settings":{"setting1":"val1"}}}}'

--- a/spec/api_header_spec.rb
+++ b/spec/api_header_spec.rb
@@ -34,7 +34,7 @@ describe SendGrid::ApiHeader do
 
     it "contains send_at" do
       ts = 5.minutes.from_now.to_i
-      header.send_at ts
+      header.add_send_at ts
       header.to_json.should eql "{\"send_at\":#{ts}}"
     end
 


### PR DESCRIPTION
As per [this thread](https://support.sendgrid.com/hc/en-us/articles/204820097-How-can-I-schedule-emails-to-send-at-specific-times-) SendGrid supports `send_at` param that allows the X-SMTPAPI users to schedule emails for later delivery.