### PR TITLE
Allow set template id to sendgrid header

### DIFF
--- a/lib/send_grid.rb
+++ b/lib/send_grid.rb
@@ -7,7 +7,7 @@ module SendGrid
   def self.included(base)
     base.class_eval do
       prepend InstanceMethods
-      delegate :substitute, :uniq_args, :category, :add_filter_setting, :deliver_at, :to => :sendgrid_header
+      delegate :substitute, :uniq_args, :category, :add_filter_setting, :deliver_at, :template_id, :to => :sendgrid_header
       alias_method :sendgrid_header, :send_grid_header
     end
   end

--- a/lib/send_grid/api_header.rb
+++ b/lib/send_grid/api_header.rb
@@ -30,6 +30,11 @@ class SendGrid::ApiHeader
     @data[:send_at] = timestamp
   end
 
+  def template_id(temp_id)
+    add_filter_setting('templates', 'enable', '1')
+    add_filter_setting('templates', 'template_id', temp_id)
+  end
+
   def to_json
     JSON.generate(@data, :array_nl => ' ')
   end

--- a/spec/api_header_spec.rb
+++ b/spec/api_header_spec.rb
@@ -38,6 +38,11 @@ describe SendGrid::ApiHeader do
       header.to_json.should eql "{\"send_at\":#{ts}}"
     end
 
+    it "contains template_id" do
+      header.template_id 'template_id_1'
+      header.to_json.should eql '{"filters":{"templates":{"settings":{"enable":"1","template_id":"template_id_1"}}}}'
+    end
+
     it "contains filter settings" do
       header.add_filter_setting :filter1, :setting1, 'val1'
       header.to_json.should eql '{"filters":{"filter1":{"settings":{"setting1":"val1"}}}}'


### PR DESCRIPTION
Allow to set template id which will be attached to sendgrid header.
This setting was described at [Sendgrid Document](https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/smtpapi.html)