### PR TITLE
Add support for suppression groups

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -8,6 +8,7 @@ It extends ActionMailer with next methods:
     category(category_string)
     open_tracking(enabled = true)
     add_filter_setting(filter_name, setting_name, value)
+    suppression_group(group_id)
 
 == Rails 3 configuration
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -3,7 +3,7 @@
 SendGrid gem provides ActionMailer::Base extensions to use SendGrid API features in you emails.
 It extends ActionMailer with next methods:
 
-    substitute(patters_string, array_of_substitunion_strings)
+    substitute(patterns_string, array_of_substitution_strings)
     uniq_args(hash_of_unique_args)
     category(category_string)
     open_tracking(enabled = true)
@@ -19,7 +19,7 @@ In your Gemfile:
 In config/initializers/mail.rb:
 
     ActionMailer::Base.register_interceptor(SendGrid::MailInterceptor)
-    
+
     ActionMailer::Base.smtp_settings = {
       :address => 'smtp.sendgrid.net',
       :port => '25',
@@ -32,7 +32,7 @@ In config/initializers/mail.rb:
 If you use Heroku, here what the mailer initializer may look like:
 
     ActionMailer::Base.register_interceptor(SendGrid::MailInterceptor)
-    
+
     if ENV['SENDGRID_USERNAME'] && ENV['SENDGRID_PASSWORD']
       ActionMailer::Base.smtp_settings = {
         :address        => 'smtp.sendgrid.net',
@@ -126,7 +126,7 @@ Add an invisible image at the end of the email to track e-mail opens. If the ema
 
 *v3.0.0*
 
-* Depricated method `:alias_method_chain` has been replaced with `Module#prepend` Ruby 2.0 feature
+* Deprecated method `:alias_method_chain` has been replaced with `Module#prepend` Ruby 2.0 feature
 * Requires Ruby 2.0+
 
 *v2.0.5*

--- a/lib/send_grid.rb
+++ b/lib/send_grid.rb
@@ -7,7 +7,7 @@ module SendGrid
   def self.included(base)
     base.class_eval do
       prepend InstanceMethods
-      delegate :substitute, :uniq_args, :category, :add_filter_setting, :deliver_at, :template_id, :to => :sendgrid_header
+      delegate :substitute, :uniq_args, :category, :add_filter_setting, :deliver_at, :template_id, :suppression_group, :to => :sendgrid_header
       alias_method :sendgrid_header, :send_grid_header
     end
   end

--- a/lib/send_grid/api_header.rb
+++ b/lib/send_grid/api_header.rb
@@ -35,6 +35,10 @@ class SendGrid::ApiHeader
     add_filter_setting('templates', 'template_id', temp_id)
   end
 
+  def suppression_group(group_id)
+    @data[:asm_group_id] = group_id.to_s
+  end
+
   def to_json
     JSON.generate(@data, :array_nl => ' ')
   end

--- a/spec/api_header_spec.rb
+++ b/spec/api_header_spec.rb
@@ -47,6 +47,10 @@ describe SendGrid::ApiHeader do
       header.add_filter_setting :filter1, :setting1, 'val1'
       header.to_json.should eql '{"filters":{"filter1":{"settings":{"setting1":"val1"}}}}'
     end
+
+    it "contains suppression_group" do
+      header.suppression_group 1234
+      header.to_json.should eql '{"asm_group_id":"1234"}'
+    end
   end
 end
-

--- a/spec/api_header_spec.rb
+++ b/spec/api_header_spec.rb
@@ -12,7 +12,7 @@ describe SendGrid::ApiHeader do
       header.to_json.should eql '{"to":[ "email@email.com" ]}'
     end
 
-    it "contaions an array of recipients" do
+    it "contains an array of recipients" do
       header.add_recipients %w(email1@email.com email2@email.com)
       header.to_json.should eql '{"to":[ "email1@email.com", "email2@email.com" ]}'
     end


### PR DESCRIPTION
I've added support for adding suppression groups to the `X-SMTPAPI` header.

See https://sendgrid.com/docs/API_Reference/SMTP_API/suppressions.html for the documentation.

And while I was at it I've fixed some spelling errors 😎 
