### PR TITLE
Use example.com for default dummy_recipient

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -49,7 +49,7 @@ If you use Heroku, here what the mailer initializer may look like:
 === Overriding default recipient in standard SMTP header
 
 Dummy recipient email used in sent email's "To" header and seen in received email's Received header.
-By default set to 'dummy@email.com'
+By default set to 'dummy@example.com'
 
 In config/initializers/mail.rb:
 
@@ -146,7 +146,7 @@ Add an invisible image at the end of the email to track e-mail opens. If the ema
 
 *v2.0.1*
 
-* Standard SMTP To attribute set to 'dummy@email.com' after recipients added to X-SMTPAPI header
+* Standard SMTP To attribute set to 'dummy@example.com' after recipients added to X-SMTPAPI header
 
 *v2.0*
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -66,7 +66,7 @@ In config/initializers/mail.rb:
               :subject => 'An email sent via SendGrid'
 
       def email_with_multiple_recipients
-        mail :to => %w(email1@email.com email2@email.com)
+        mail :to => %w(email1@example.com email2@example.com)
       end
     end
 
@@ -81,7 +81,7 @@ Mailer class definition:
       def email_with_substitutions
         substitute '-user_name-', %w(User1 User2)
 
-        mail :to => %w(email1@email.com email2@email.com), :body => "Hello, -user_name-!"
+        mail :to => %w(email1@example.com email2@example.com), :body => "Hello, -user_name-!"
       end
     end
 
@@ -95,7 +95,7 @@ Mailer class definition:
 
       def email_with_category
         category 'SendGridRocks'
-        mail :to => 'email1@email.com'
+        mail :to => 'email1@example.com'
       end
     end
 
@@ -113,7 +113,7 @@ Add an invisible image at the end of the email to track e-mail opens. If the ema
 
       def email_with_open_tracking_enabled
         open_tracking true
-        mail :to => 'email@email.com'
+        mail :to => 'email@example.com'
       end
     end
 

--- a/lib/send_grid/config.rb
+++ b/lib/send_grid/config.rb
@@ -2,6 +2,6 @@ class SendGrid::Config
   attr_accessor :dummy_recipient
 
   def initialize
-    @dummy_recipient = "dummy@email.com"
+    @dummy_recipient = "dummy@example.com"
   end
 end

--- a/spec/api_header_spec.rb
+++ b/spec/api_header_spec.rb
@@ -8,13 +8,13 @@ describe SendGrid::ApiHeader do
     end
 
     it "contains 1 recipient (as array)" do
-      header.add_recipients 'email@email.com'
-      header.to_json.should eql '{"to":[ "email@email.com" ]}'
+      header.add_recipients 'email@example.com'
+      header.to_json.should eql '{"to":[ "email@example.com" ]}'
     end
 
     it "contaions an array of recipients" do
-      header.add_recipients %w(email1@email.com email2@email.com)
-      header.to_json.should eql '{"to":[ "email1@email.com", "email2@email.com" ]}'
+      header.add_recipients %w(email1@example.com email2@example.com)
+      header.to_json.should eql '{"to":[ "email1@example.com", "email2@example.com" ]}'
     end
 
     it "contains substitution" do
@@ -49,4 +49,3 @@ describe SendGrid::ApiHeader do
     end
   end
 end
-

--- a/spec/fixtures/mailers/mailer.rb
+++ b/spec/fixtures/mailers/mailer.rb
@@ -12,7 +12,6 @@ class Mailer < ActionMailer::Base
 
   def email_open_tracking(opentrack_enabled = true)
     open_tracking opentrack_enabled
-    mail :to => 'email@email.com', :body => 'Hello!'
+    mail :to => 'email@example.com', :body => 'Hello!'
   end
 end
-

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -45,10 +45,10 @@ describe Mailer do
 
   describe 'dummy_recipient used in TO is taken from config' do
     it 'should be used in TO default dummy_recipient' do
-      # by defaut dummy_recipient's email is dummy@email.com
+      # by defaut dummy_recipient's email is dummy@example.com
 
       Mailer.email_with_multiple_recipients(%w(em1@email.com em2@email.com)).deliver.header.to_s.
-        should include('To: dummy@email.com')
+        should include('To: dummy@example.com')
     end
 
     it 'should be used in To defined in config dummy_recipient' do

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -3,16 +3,16 @@ require 'spec_helper'
 describe Mailer do
   describe 'email with multiple recipients' do
     it 'set correct recipients in X-SMTAPI header' do
-      Mailer.email_with_multiple_recipients(%w(em1@email.com em2@email.com)).deliver.header.to_s.
-        should include('X-SMTPAPI: {"to":[ "em1@email.com", "em2@email.com" ]}')
+      Mailer.email_with_multiple_recipients(%w(em1@example.com em2@example.com)).deliver.header.to_s.
+        should include('X-SMTPAPI: {"to":[ "em1@example.com", "em2@example.com" ]}')
 
-      Mailer.email_with_cc_recipients(%w(em1@email.com), %w(cc@email.com), %w(bcc@email.com)).deliver.header.to_s.
-        should include('X-SMTPAPI: {"to":[ "em1@email.com", "cc@email.com", "bcc@email.com" ]}')
+      Mailer.email_with_cc_recipients(%w(em1@example.com), %w(cc@example.com), %w(bcc@example.com)).deliver.header.to_s.
+        should include('X-SMTPAPI: {"to":[ "em1@example.com", "cc@example.com", "bcc@example.com" ]}')
     end
 
     it 'removes original TO header part' do
-      Mailer.email_with_multiple_recipients(%w(em1@email.com em2@email.com)).deliver.header.to_s.
-        should_not include("To: em1@email.com")
+      Mailer.email_with_multiple_recipients(%w(em1@example.com em2@example.com)).deliver.header.to_s.
+        should_not include("To: em1@example.com")
     end
 
     it 'maintains recommended header line length' do
@@ -47,7 +47,7 @@ describe Mailer do
     it 'should be used in TO default dummy_recipient' do
       # by defaut dummy_recipient's email is dummy@example.com
 
-      Mailer.email_with_multiple_recipients(%w(em1@email.com em2@email.com)).deliver.header.to_s.
+      Mailer.email_with_multiple_recipients(%w(em1@example.com em2@example.com)).deliver.header.to_s.
         should include('To: dummy@example.com')
     end
 
@@ -58,7 +58,7 @@ describe Mailer do
         config.dummy_recipient = 'noreply@example.com'
       end
 
-      Mailer.email_with_multiple_recipients(%w(em1@email.com em2@email.com)).deliver.header.to_s.
+      Mailer.email_with_multiple_recipients(%w(em1@example.com em2@example.com)).deliver.header.to_s.
         should include('To: noreply@example.com')
     end
   end


### PR DESCRIPTION
To fix #24 I've changed the default dummy_recipient to an example.com email address. For consistency, I've also changed all the email addresses in the specs and the docs to use this domain.
