### PR TITLE
Make dummy_recipient optional

### DIFF
--- a/lib/send_grid/mail_interceptor.rb
+++ b/lib/send_grid/mail_interceptor.rb
@@ -6,7 +6,7 @@ module SendGrid
       sendgrid_header.add_recipients(mail.cc)
       sendgrid_header.add_recipients(mail.bcc)
       mail.header['X-SMTPAPI'] = sendgrid_header.to_json if sendgrid_header.data.present?
-      mail.header['to'] = SendGrid.config.dummy_recipient
+      mail.header['to'] = SendGrid.config.dummy_recipient || mail.to.first
     end
   end
 end

--- a/spec/mailer_spec.rb
+++ b/spec/mailer_spec.rb
@@ -61,5 +61,16 @@ describe Mailer do
       Mailer.email_with_multiple_recipients(%w(em1@email.com em2@email.com)).deliver.header.to_s.
         should include('To: noreply@example.com')
     end
+
+    it 'should use first email address in To when no dummy_recipient is defined' do
+      # dummy_recipient can be redefined config/initializers
+
+      SendGrid.configure do |config|
+        config.dummy_recipient = nil
+      end
+
+      Mailer.email_with_multiple_recipients(%w(em1@example.com em2@example.com)).deliver.header.to_s.
+        should include('To: em1@example.com')
+    end
   end
 end


### PR DESCRIPTION
Maybe this feature is unneeded and is it's creation caused by my misunderstanding of the use for this `dummy_recipient`.

What is unclear to me is if Sendgrid actually will send the email to both the recipient in the `To:` header as in the `to:` array in `X-SMTPAPI`. For me it's important that the email is addressed to the actual recipient and not to some `noreply@example.com` address.

In my app I never send out any emails to multiple recipients, so for me the fix is fine. I'm open to other suggestions too btw.
